### PR TITLE
[ADD] slack id mapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const DialogBuilder = require('./src/DialogBuilder');
 const SlackActionRequest = require('./src/SlackActionRequest');
 const PluginsLoader = require('./src/PluginsLoader');
 const Locales = require('./src/Locales');
+const SlackIdMapper = require('./src/SlackIdMapper');
 
 module.exports = {
   botCron,
@@ -35,6 +36,7 @@ module.exports = {
   SlackActionRequest,
   PluginsLoader,
   Locales,
+  SlackIdMapper,
   clients: {
     AtlassianClientFactory,
     CircleciClientFactory,
@@ -42,5 +44,5 @@ module.exports = {
     GoogleCalendarClientFactory,
     RedisClientFactory,
     SlackClientFactory,
-  }
+  },
 };

--- a/src/SlackIdMapper/index.js
+++ b/src/SlackIdMapper/index.js
@@ -1,0 +1,3 @@
+const SlackIdMapper = require('./src/SlackIdMapper');
+
+module.exports = SlackIdMapper;

--- a/src/SlackIdMapper/src/SlackIdMapper.js
+++ b/src/SlackIdMapper/src/SlackIdMapper.js
@@ -1,0 +1,76 @@
+/* eslint-disable class-methods-use-this */
+const slackClientFactory = require('../../clients/SlackClientFactory');
+
+class SlackIdMapper {
+  constructor(slackClient = slackClientFactory()) {
+    this.client = slackClient;
+  }
+
+  retreiveCursor(metadata) {
+    if (metadata && metadata.next_cursor) {
+      return metadata.next_cursor;
+    }
+
+    return null;
+  }
+
+  async requestUsers(nextCursor) {
+    const params = {};
+    if (nextCursor) {
+      params.cursor = nextCursor;
+    }
+
+    const {
+      members,
+      response_metadata: metadata,
+    } = await this.client.users.list(params);
+
+    const cursor = this.retreiveCursor(metadata);
+
+    return { members, cursor };
+  }
+
+  isEqualNoDomain(googleEmail, slackEmail) {
+    if (!slackEmail) {
+      return false;
+    }
+
+    return slackEmail && googleEmail
+      && googleEmail.replace(/\.[^.]+$/, '') === slackEmail.replace(/\.[^.]+$/, '');
+  }
+
+  mapEmailsToSlackIds(usersEmails = [], members) {
+    return members.reduce((store, member) => {
+      const googleEmail = usersEmails.find(
+        email => this.isEqualNoDomain(email, member.profile.email),
+      );
+
+      if (!googleEmail) {
+        return store;
+      }
+
+      return { ...store, [googleEmail]: member.id };
+    }, {});
+  }
+
+  async getUserId(userEmail) {
+    const mappedUsers = await this.getMappedSlackUsers([userEmail]);
+
+    return mappedUsers[userEmail];
+  }
+
+  async getMappedSlackUsers(usersEmails, nextCursor = '', mappedAlready = {}) {
+    const { members, cursor } = await this.requestUsers(nextCursor);
+
+    const mappedUsers = { ...mappedAlready, ...this.mapEmailsToSlackIds(usersEmails, members) };
+    const mapCount = Object.keys(mappedUsers).length;
+
+    if (!cursor || mapCount === usersEmails.length) {
+      return mappedUsers;
+    }
+
+    return this.getMappedSlackUsers(usersEmails, cursor, mappedUsers);
+  }
+}
+
+module.exports = SlackIdMapper;

--- a/test/SlackIdMapper.spec.js
+++ b/test/SlackIdMapper.spec.js
@@ -1,0 +1,211 @@
+/* eslint-disable no-trailing-spaces */
+const sinon = require('sinon');
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+
+const { expect } = chai;
+
+const SlackIdMapper = require('../src/SlackIdMapper');
+
+describe('Slack emails to ids mapper', () => {
+  const userEmails = ['super@malpka.pl'];
+  let usersIdMapper;
+
+  const responseOk = {
+    ok: true,
+    members: [
+      {
+        id: 'P23OA23D9',
+        profile: {
+          email: userEmails[0],
+        },
+      },
+      {
+        id: 'W012A3CDE',
+        profile: {
+          email: 'hoho@email.example.com',
+        },
+      },
+    ],
+    response_metadata: {
+      next_cursor: 'dXNlcjpVMEc5V0ZYTlo=',
+    },
+  };
+
+  const responseOkNoMetadata = {
+    ok: true,
+    members: [
+      {
+        id: 'AADKWL',
+        profile: {
+          email: userEmails[0],
+        },
+      },
+      {
+        id: 'AAAQQDDD',
+        profile: {
+          email: 'hoho@email.example.com',
+        },
+      },
+      {
+        id: 'BOT',
+        profile: {
+          no_email: '',
+        },
+      },
+    ],
+    response_metadata: {
+      next_cursor: '',
+    },
+  };
+
+  const tick = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+  afterEach(() => sinon.restore());
+
+  describe('requestUsers', () => {
+    beforeEach(() => {
+      usersIdMapper = new SlackIdMapper();
+    });
+
+    it('Should return a valid list of users from cursor', async () => {
+      sinon.stub(usersIdMapper.client.users, 'list').returns(responseOk);
+
+      const result = await usersIdMapper.requestUsers();
+
+      expect(result).to.eql({
+        members: responseOk.members,
+        cursor: responseOk.response_metadata.next_cursor,
+      });
+    });
+  });
+
+  describe('getMappedSlackUsers', () => {
+    it('Should return users with their ids', async () => {
+      sinon.stub(usersIdMapper, 'requestUsers').resolves(responseOkNoMetadata);
+
+      const result = await usersIdMapper.getMappedSlackUsers(userEmails);
+
+      expect(result).to.deep.equal({
+        [responseOkNoMetadata.members[0].profile.email]: responseOkNoMetadata.members[0].id,
+      });
+    });
+
+    it('Should return users with their ids even if domains are different', async () => {
+      sinon.stub(usersIdMapper, 'requestUsers').resolves(responseOkNoMetadata);
+
+      const result = await usersIdMapper.getMappedSlackUsers(['super@malpka.com']);
+
+      expect(result).to.deep.equal({
+        'super@malpka.com': responseOkNoMetadata.members[0].id,
+      });
+    });
+
+    it('Should return users after one pagination', async () => {
+      const stubbedEmail = 'stub@emal.com';
+      const stubbedId = 'O23SDA';
+
+      sinon.stub(responseOk.members[0].profile, 'email').value(stubbedEmail);
+      sinon.stub(responseOk.members[0], 'id').value(stubbedId);
+
+      usersIdMapper = new SlackIdMapper({
+        users: {
+          list: async (params) => {
+            if (!params.cursor) {
+              return responseOk;
+            }
+            return responseOkNoMetadata;
+          },
+        },
+      });
+
+      const emails = [...userEmails, stubbedEmail];
+      const result = await usersIdMapper.getMappedSlackUsers(emails);
+
+      expect(result).to.deep.equal({
+        [responseOkNoMetadata.members[0].profile.email]: responseOkNoMetadata.members[0].id,
+        [stubbedEmail]: stubbedId,
+      });
+    });
+
+    it('Should return user id', async () => {
+      const stubbedEmail = 'stub@emal.com';
+      const stubbedId = 'O23SDA';
+
+      sinon.stub(responseOk.members[0].profile, 'email').value(stubbedEmail);
+      sinon.stub(responseOk.members[0], 'id').value(stubbedId);
+
+      usersIdMapper = new SlackIdMapper({
+        users: {
+          list: async (params) => {
+            if (!params.cursor) {
+              return responseOk;
+            }
+            return responseOkNoMetadata;
+          },
+        },
+      });
+
+      const result = await usersIdMapper.getUserId(stubbedEmail);
+
+      expect(result).to.equal(stubbedId);
+    });
+
+    it('Should stop calling slack api when all users found', async () => {
+      usersIdMapper = new SlackIdMapper({
+        users: {
+          list: async (params) => {
+            if (!params.cursor) {
+              return responseOk;
+            }
+            return responseOkNoMetadata;
+          },
+        },
+      });
+
+      const mapperSpy = sinon.spy(usersIdMapper, 'getMappedSlackUsers');
+
+      const emails = [...userEmails];
+      const result = await usersIdMapper.getMappedSlackUsers(emails);
+
+      await tick(1);
+
+      expect(result).to.deep.equal({
+        [userEmails[0]]: responseOk.members[0].id,
+      });
+
+      expect(mapperSpy.calledOnce).to.equal(true);
+    });
+
+
+    it('Should return only available users', async () => {
+      const notFoundEmail = 'notfound@emal.com';
+
+      usersIdMapper = new SlackIdMapper({
+        users: {
+          list: async (params) => {
+            if (!params.cursor) {
+              return responseOk;
+            }
+            return responseOkNoMetadata;
+          },
+        },
+      });
+
+      const emails = [...userEmails, notFoundEmail];
+      const result = await usersIdMapper.getMappedSlackUsers(emails);
+
+      expect(result).to.deep.equal({
+        [responseOkNoMetadata.members[0].profile.email]: responseOkNoMetadata.members[0].id,
+      });
+    });
+
+    it('Should resolve with an empty array if no userEmails specified', async () => {
+      sinon.stub(usersIdMapper, 'requestUsers').resolves(responseOkNoMetadata);
+
+      const result = await usersIdMapper.getMappedSlackUsers();
+
+      expect(result).to.eql({});
+    });
+  });
+});


### PR DESCRIPTION
## Changes

Added the slack id mapper which was currently used explicitly by one plugin however I anticipate that it will be used in the future features as well. Also added a `getUserId` method that returns userId based on given email.