### PR TITLE
[Improvement] Locales on tests

### DIFF
--- a/src/Locales/src/Locales.js
+++ b/src/Locales/src/Locales.js
@@ -45,7 +45,9 @@ class Locales {
     const data = this.getDataFromFile(key);
 
     if (Array.isArray(data)) {
-      return Locales.renderMessage(_.sample(data), params);
+      return process.env.NODE_ENV === 'test'
+        ? Locales.renderMessage(data[0], params)
+        : Locales.renderMessage(_.sample(data), params);
     }
 
     if (!['string', 'number'].includes(typeof data)) {

--- a/test/Locales.spec.js
+++ b/test/Locales.spec.js
@@ -85,7 +85,9 @@ describe('Locales util test suite', () => {
       expect(getValue).to.throw('Selected locale is not a string, number nor array');
     });
 
-    it('get random value from key', () => {
+    it('get random value from key if NODE_ENV is not test', () => {
+      sinon.stub(process, 'env').value({ ...process.env, NODE_ENV: 'development' });
+
       const subject = new Locales({ plugin: 'test' });
       const data = ['first', 'second', 'third'];
 
@@ -94,6 +96,19 @@ describe('Locales util test suite', () => {
       const result = subject.get('values');
 
       expect(data).to.include(result);
+    });
+
+    it('get value with index 0 from array when NODE_ENV is test', () => {
+      sinon.stub(process, 'env').value({ ...process.env, NODE_ENV: 'test' });
+
+      const subject = new Locales({ plugin: 'test' });
+      const data = ['first', 'second', 'third'];
+
+      sinon.stub(yaml, 'safeLoad').returns({ values: data });
+
+      const result = subject.get('values');
+
+      expect(data[0]).to.equal(result);
     });
 
     it('get random value from nested key and renders parameter', () => {


### PR DESCRIPTION
## Description

When testing with random locales (arrays of values) the randomization of the results requires a developer to stub the `lodash.sample`. In the case when the non-developer would like to change the single value to the arrays of value to randomize the output that person would most certainly head into the failing tests.

## Changes

* Added a case to the randomization process that if `NODE_ENV === 'test` it would always take the first value from the array.