### PR TITLE
[Improve] Slack action multiplexer error data logging

### DIFF
--- a/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
+++ b/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
@@ -62,6 +62,14 @@ class SlackActionsMultiplexer {
       } catch (error) {
         Rollbar.error(error);
         logger.error(error);
+
+        if (error.data) {
+          logger.info({
+            error: JSON.stringify(error.data),
+            actionJSONPayload,
+          });
+        }
+
         res.sendStatus(500);
       }
     });


### PR DESCRIPTION
## Description

Currently, if an error with slack action happens the error `response_metadata` property is logged with `messages: [Array]` which makes further investigation much harder.

## Changes

* Added a statement where the `error.data` should be stringified and logged if it is available, also added the payload to be logged in this case as it may be useful. 