### PR TITLE
[Fix] jira rollbar

### DIFF
--- a/src/clients/JiraClient.js
+++ b/src/clients/JiraClient.js
@@ -24,9 +24,11 @@ class JiraClient {
 
       return data;
     } catch (err) {
-      rollbar.error(err);
-      assertOrThrow(this.isAuthenticated(err.response), new Error('Is not authenticated'));
       assertOrThrow(this.notStatusError(err.response), new Error('Wrong status'));
+
+      rollbar.error(err);
+
+      assertOrThrow(this.isAuthenticated(err.response), new Error('Is not authenticated'));
 
       throw Error('Request error');
     }

--- a/test/jira.client.spec.js
+++ b/test/jira.client.spec.js
@@ -45,6 +45,7 @@ describe('Unit tests - Jira Client', () => {
 
     it('should throw not authenticated error', async () => {
       sinon.stub(jiraClient, 'axios').rejects('err');
+      sinon.stub(jiraClient, 'notStatusError').returns(true);
       sinon.stub(jiraClient, 'isAuthenticated').returns(false);
 
       await expect(jiraClient.request('/api', { query: { param: 1 } }, 'get'))


### PR DESCRIPTION
It was easy to spam rollbar with errors, it only took user to specify ticket number that doesn't yet exist, to rollbar an error.