### PR TITLE
[BOB-70] No results error on conflu pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "rollbar": "^2.5.0",
     "sinon": "^6.1.5",
     "toml": "^2.3.3",
+    "unescape": "^1.0.1",
     "yargs": "^12.0.1"
   },
   "engines": {

--- a/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
+++ b/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
@@ -107,10 +107,11 @@ class SlackActionsMultiplexer {
   }
 
   unescapeQueryParamsInActionPayload(payload) {
-    let payloadJSON = JSON.parse(payload);
-    const queryParams = _.get(payloadJSON, 'actions[0].selected_options[0].value');
-    if(typeof queryParams === 'string' || queryParams instanceof String) {
-      payloadJSON.actions[0].selected_options[0].value = decode(queryParams);
+    const payloadJSON = JSON.parse(payload);
+    const queryPath = 'actions[0].selected_options[0].value';
+    const queryParams = _.result(payloadJSON, queryPath);
+    if(_.isString(queryParams)) {
+      _.set(payloadJSON, queryPath, decode(queryParams));
     }
     return payloadJSON;
   }

--- a/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
+++ b/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
@@ -51,6 +51,16 @@ class SlackActionsMultiplexer {
     }
   }
 
+  unescapeQueryParamsInActionPayload(payload) {
+    const payloadJSON = JSON.parse(payload);
+    const queryPath = 'actions[0].selected_options[0].value';
+    const queryParams = _.result(payloadJSON, queryPath);
+    if(_.isString(queryParams)) {
+      _.set(payloadJSON, queryPath, decode(queryParams));
+    }
+    return payloadJSON;
+  }
+
   createRoutesForActions(logger) {
     this.robot.router.post(actionsEndpoint, async (req, res) => {
       const actionJSONPayload = this.unescapeQueryParamsInActionPayload(req.body.payload);
@@ -104,16 +114,6 @@ class SlackActionsMultiplexer {
   slashCommandIdAlreadyExists(regexp) {
     return _.some(this.slashActionsMultiplexer.responses,
       ({ trigger }) => trigger.toString() === regexp.toString());
-  }
-
-  unescapeQueryParamsInActionPayload(payload) {
-    const payloadJSON = JSON.parse(payload);
-    const queryPath = 'actions[0].selected_options[0].value';
-    const queryParams = _.result(payloadJSON, queryPath);
-    if(_.isString(queryParams)) {
-      _.set(payloadJSON, queryPath, decode(queryParams));
-    }
-    return payloadJSON;
   }
 }
 

--- a/test/SlackActionsMultiplexer.spec.js
+++ b/test/SlackActionsMultiplexer.spec.js
@@ -40,6 +40,25 @@ describe('SlackActionsMultiplexer test suite', () => {
     expect(() => slackActions.addAction(/some_cb/, () => { })).to.throw('Callback id duplication');
   });
 
+  it('Should unescape HTML entities in query params', () => {
+    const payload = JSON.stringify({
+      callback_id: 'callback',
+      actions: [
+        {
+          selected_options: [
+            {
+              value: '{"title":"\'&lt;foo&gt; &amp; bar""}',
+            },
+          ],
+        },
+      ],
+    });
+    const unescapedPayload = slackActions.unescapeQueryParamsInActionPayload(payload);
+    const queryParams = unescapedPayload.actions[0].selected_options[0].value;
+
+    expect(queryParams).to.equal('{"title":"\'<foo> & bar""}');
+  });
+
   it('responds with status 500 and throws error when callback is not specified', async () => {
     const payload = JSON.stringify({ text: 'example' });
 
@@ -51,7 +70,7 @@ describe('SlackActionsMultiplexer test suite', () => {
   });
 
   it('Should throw an error in case of callback duplicate', () => {
-    slackActions.addSlashCommand(/some_cb/, () => { });
+    slackActions.addSlashCommand(/some_cb/, () => {});
 
     expect(() => slackActions.addSlashCommand(/some_cb/, () => { })).to.throw('Slash command duplication');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3654,6 +3654,13 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+unescape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unescape/-/unescape-1.0.1.tgz#956e430f61cad8a4d57d82c518f5e6cc5d0dda96"
+  integrity sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==
+  dependencies:
+    extend-shallow "^2.0.1"
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"


### PR DESCRIPTION
### Issue:
HTML characters in payload are in HTML entity format. Example:
```
<head> -> &lt;head&gt; 
```
Once it is URI encoded we get something like this 
```
%26lt%3Bhead%26gt%3B 
```
instead of 
```
%3Chead%3E
```

### Solution:
Query params are transformed from HTML entities to HTML characters in action payload before any action runs.