### PR TITLE
BOB-82 enabling interactivity with block components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 .nyc_output
 .env
 .env.test
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .nyc_output
 .env
 .env.test
+.vscode

--- a/src/MessageBuilder/src/MessageBuilder.js
+++ b/src/MessageBuilder/src/MessageBuilder.js
@@ -3,11 +3,17 @@ const _ = require('lodash');
 class MessageBuilder {
   constructor(params = {}) {
     this.attachments = [];
+    this.blocks = [];
     this.options = params;
   }
 
   addAttachment(params = {}) {
     this.attachments.push(params);
+    return this;
+  }
+
+  addBlock(block = {}) {
+    this.blocks.push(block);
     return this;
   }
 
@@ -27,7 +33,10 @@ class MessageBuilder {
 
   buildMessage(params = {}) {
     return {
-      ...(this.attachments.length && { attachments: this.attachments }), ...this.options, ...params,
+      ...(this.attachments.length && { attachments: this.attachments }),
+      ...(this.blocks.length && { blocks: this.blocks }),
+      ...this.options,
+      ...params,
     };
   }
 }

--- a/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
+++ b/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
@@ -17,7 +17,7 @@ class SlackActionsMultiplexer {
     this.blockActionMultiplexer = new RespondMultiplexer(logger);
     this.slashActionsMultiplexer = new RespondMultiplexer(logger);
 
-    this.assignActionMultiplexers();
+    this.setupActionMultiplexers();
     this.setDefaultResponse();
 
     this.createRoutesForInteractive(logger);
@@ -77,7 +77,7 @@ class SlackActionsMultiplexer {
 
       try {
         await this.sendResponseMessage(actionJSONPayload);
-        const { multiplexer, path } = this.selectInteractiveMultiplexer(actionJSONPayload);
+        const { multiplexer, path } = this.getInteractiveMultiplexer(actionJSONPayload);
 
         multiplexer.choose(_.get(actionJSONPayload, path));
         await multiplexer.chosen.action(res, actionJSONPayload, this.robot);
@@ -112,7 +112,7 @@ class SlackActionsMultiplexer {
     });
   }
 
-  assignActionMultiplexers() {
+  setupActionMultiplexers() {
     const assignMultiplexer = (multiplexer, path) => ({ multiplexer, path });
     this.interactiveMultiplexers = new Map([
       ['interactive_message', assignMultiplexer(this.actionMultiplexer, 'callback_id')],
@@ -120,12 +120,9 @@ class SlackActionsMultiplexer {
     ]);
   }
 
-  selectInteractiveMultiplexer({ type } = {}) {
+  getInteractiveMultiplexer({ type } = {}) {
     const muxData = this.interactiveMultiplexers.get(type);
-    if (!muxData) {
-      throw Error('Unknown interactive message type');
-    }
-    return muxData;
+    return muxData || this.interactiveMultiplexers.get('interactive_message');
   }
 
   setDefaultResponse() {

--- a/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
+++ b/src/SlackActionsMultiplexer/src/SlackActionsMultiplexer.js
@@ -13,11 +13,14 @@ class SlackActionsMultiplexer {
 
     const { logger } = robot;
 
-    this.multiplexer = new RespondMultiplexer(logger);
+    this.actionMultiplexer = new RespondMultiplexer(logger);
+    this.blockActionMultiplexer = new RespondMultiplexer(logger);
     this.slashActionsMultiplexer = new RespondMultiplexer(logger);
 
+    this.assignActionMultiplexers();
     this.setDefaultResponse();
-    this.createRoutesForActions(logger);
+
+    this.createRoutesForInteractive(logger);
     this.createRoutesForSlash(logger);
   }
 
@@ -25,7 +28,14 @@ class SlackActionsMultiplexer {
     if (this.actionIdAlreadyExists(regexp)) {
       throw new Error('Callback id duplication');
     }
-    this.multiplexer.addResponse(regexp, action);
+    this.actionMultiplexer.addResponse(regexp, action);
+  }
+
+  addBlock(regexp, action) {
+    if (this.blockIdAlreadyExists(regexp)) {
+      throw new Error('Block id duplication');
+    }
+    this.blockActionMultiplexer.addResponse(regexp, action);
   }
 
   addSlashCommand(regexp, action) {
@@ -55,21 +65,22 @@ class SlackActionsMultiplexer {
     const payloadJSON = JSON.parse(payload);
     const queryPath = 'actions[0].selected_options[0].value';
     const queryParams = _.result(payloadJSON, queryPath);
-    if(_.isString(queryParams)) {
+    if (_.isString(queryParams)) {
       _.set(payloadJSON, queryPath, decode(queryParams));
     }
     return payloadJSON;
   }
 
-  createRoutesForActions(logger) {
+  createRoutesForInteractive(logger) {
     this.robot.router.post(actionsEndpoint, async (req, res) => {
       const actionJSONPayload = this.unescapeQueryParamsInActionPayload(req.body.payload);
 
       try {
         await this.sendResponseMessage(actionJSONPayload);
+        const { multiplexer, path } = this.selectInteractiveMultiplexer(actionJSONPayload);
 
-        this.multiplexer.choose(actionJSONPayload.callback_id);
-        await this.multiplexer.chosen.action(res, actionJSONPayload, this.robot);
+        multiplexer.choose(_.get(actionJSONPayload, path));
+        await multiplexer.chosen.action(res, actionJSONPayload, this.robot);
       } catch (error) {
         Rollbar.error(error);
         logger.error(error);
@@ -88,7 +99,7 @@ class SlackActionsMultiplexer {
 
   createRoutesForSlash(logger) {
     this.robot.router.post(slashEndpoint, async (req, res) => {
-      const { text, command } = req.body;
+      const { command } = req.body;
 
       try {
         this.slashActionsMultiplexer.choose(command);
@@ -101,19 +112,43 @@ class SlackActionsMultiplexer {
     });
   }
 
+  assignActionMultiplexers() {
+    const assignMultiplexer = (multiplexer, path) => ({ multiplexer, path });
+    this.interactiveMultiplexers = new Map([
+      ['interactive_message', assignMultiplexer(this.actionMultiplexer, 'callback_id')],
+      ['block_actions', assignMultiplexer(this.blockActionMultiplexer, 'actions[0].action_id')],
+    ]);
+  }
+
+  selectInteractiveMultiplexer({ type } = {}) {
+    const muxData = this.interactiveMultiplexers.get(type);
+    if (!muxData) {
+      throw Error('Unknown interactive message type');
+    }
+    return muxData;
+  }
+
   setDefaultResponse() {
-    this.multiplexer.setDefaultResponse(() => { throw Error('No callback found'); });
+    this.actionMultiplexer.setDefaultResponse(() => { throw Error('No callback found'); });
+    this.blockActionMultiplexer.setDefaultResponse(() => { throw Error('No block action found'); });
     this.slashActionsMultiplexer.setDefaultResponse(() => { throw Error('No slash command found'); });
   }
 
-  actionIdAlreadyExists(regexp) {
-    return _.some(this.multiplexer.responses,
+  checkIdCollision(regexp, multiplexer) {
+    return _.some(multiplexer.responses,
       ({ trigger }) => trigger.toString() === regexp.toString());
   }
 
+  actionIdAlreadyExists(regexp) {
+    return this.checkIdCollision(regexp, this.actionMultiplexer);
+  }
+
+  blockIdAlreadyExists(regexp) {
+    return this.checkIdCollision(regexp, this.blockActionMultiplexer);
+  }
+
   slashCommandIdAlreadyExists(regexp) {
-    return _.some(this.slashActionsMultiplexer.responses,
-      ({ trigger }) => trigger.toString() === regexp.toString());
+    return this.checkIdCollision(regexp, this.slashActionsMultiplexer);
   }
 }
 

--- a/test/MessageBuilder.spec.js
+++ b/test/MessageBuilder.spec.js
@@ -44,6 +44,24 @@ describe('MessageBuilder', () => {
         text: 'Hello world', x: 'y', z: 'x', attachments: [{ name: 'eoeo' }],
       });
     });
+
+    it('should build message with blocks', () => {
+      const builder = new MessageBuilder({ text: 'Hello world' });
+      builder.addBlock({ name: 'eoeo' });
+
+      const result = builder.buildMessage();
+      expect(result).to.eql({ text: 'Hello world', blocks: [{ name: 'eoeo' }] });
+    });
+
+    it('should operate with chain methods on blocks', () => {
+      const builder = new MessageBuilder({ text: 'Hello world' });
+      builder.addBlock({ name: 'eoeo' }).addBlock({ name: 'foo' });
+
+      const result = builder.buildMessage();
+      expect(result).to.eql({
+        text: 'Hello world', blocks: [{ name: 'eoeo' }, { name: 'foo' }],
+      });
+    });
   });
 
   describe('Other functions', () => {


### PR DESCRIPTION
Adding separate blockAction multiplexer to handle Interactive Messages

This is an enhancement which allows to register and extract specific data from
block_actions of Interactive Messages.

See more details at https://api.slack.com/messaging/attachments-to-blocks#callback_id_replacement