### PR TITLE
disable plugins with missing env variables

### DIFF
--- a/src/PluginsLoader/src/PluginsLoader.js
+++ b/src/PluginsLoader/src/PluginsLoader.js
@@ -48,13 +48,22 @@ class PluginsLoader {
       throw new Error(`Plugin ${pluginName} is not present in the configuration, please run: yarn docs`);
     }
 
+    let correctConfig = true;
     pluginConfig.forEach((envName) => {
       if (!(envName in process.env)) {
-        this.robot.logger.warning(`The enviromental variable \x1b[36m ${envName} \x1b[0m is missing for plugin \x1b[35m ${pluginName} \x1b[0m`);
+        this.robot.logger.warning(`The environmental variable \x1b[36m ${envName} \x1b[0m is missing for plugin \x1b[35m ${pluginName} \x1b[0m`);
+        correctConfig = false;
+      } else if(!process.env[envName]) {
+        this.robot.logger.warning(`The environmental variable \x1b[36m ${envName} \x1b[0m from \x1b[35m ${pluginName} \x1b[0m plugin does not have specified value`);
+        correctConfig = false;
       }
     });
 
-    this.robot.load(pluginPath);
+    if (!correctConfig) {
+      return this.robot.logger.warning(`\x1b[31m Plugin \x1b[4m ${pluginName} \x1b[0m \x1b[31m is turned off \x1b[0m`);
+    }
+
+    return this.robot.load(pluginPath);
   }
 }
 

--- a/test/PluginsLoader.spec.js
+++ b/test/PluginsLoader.spec.js
@@ -14,6 +14,7 @@ const errorMessages = {
 const pluginNames = [
   'pluginOne',
   'pluginTwo',
+  'pluginThree',
 ];
 
 const configuration = {
@@ -25,10 +26,14 @@ const configuration = {
     'CC',
     'DD',
   ],
+  [pluginNames[2]]: [
+    'EE',
+  ],
 };
 
 const enabled = [
   pluginNames[0],
+  pluginNames[2],
 ];
 
 describe('PluginsLoader test scope', () => {
@@ -58,15 +63,16 @@ describe('PluginsLoader test scope', () => {
 
     afterEach(() => sinon.restore());
 
-    it('Should load plugins and warn about missing enviromental variables', () => {
+    it('Should load plugins and warn about missing environmental variables', () => {
       sinon.stub(fs, 'readdirSync').returns(pluginNames);
       sinon.stub(path, 'resolve').returns('ab/acd');
       sinon.stub(process, 'env').value({ AA: 1 });
+      sinon.stub(process, 'env').value({ EE: 1 });
 
       pluginsLoader.loadPlugins('ac/dv');
 
       expect(pluginsLoader.robot.load.calledOnceWith('ab/acd')).to.equal(true);
-      expect(pluginsLoader.robot.logger.warning.calledTwice).to.equal(true);
+      expect(pluginsLoader.robot.logger.warning.callCount).to.equal(4);
     });
 
     it('Should throw an error if plugin does not have its configuration', () => {


### PR DESCRIPTION
- now warns when empty env is passed
- disables plugin when any required env is missing or is empty